### PR TITLE
Set adapter log level

### DIFF
--- a/plugins/action/set_adapter_log_level.py
+++ b/plugins/action/set_adapter_log_level.py
@@ -4,14 +4,18 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 # Sets the logging level for a specific Itential Platform adapter.
+#
 # Parameters:
-#   adapter_name: Name of the adapter
-#   log_level: Desired log level (debug, info, warn, error)
-# Example:
-#   - name: Set adapter logging to debug
+#   adapter_name: Name of the adapter (e.g., "network-adapter")
+#   log_level: Desired log level ("debug", "info", "warn", "error")
+#   transport: Logging transport ("file" or "console")
+#
+# Example usage:
+#   - name: Set adapter logging to debug using file transport
 #     itential.platform.set_adapter_log_level:
 #       adapter_name: network-adapter
 #       log_level: debug
+#       transport: file
 
 from ansible.plugins.action import ActionBase
 from ansible_collections.itential.platform.plugins.module_utils.request import make_request

--- a/plugins/action/set_adapter_log_level.py
+++ b/plugins/action/set_adapter_log_level.py
@@ -1,0 +1,45 @@
+# Copyright 2024, Itential Inc. All Rights Reserved
+
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Sets the logging level for a specific Itential Platform adapter.
+# Parameters:
+#   adapter_name: Name of the adapter
+#   log_level: Desired log level (debug, info, warn, error)
+# Example:
+#   - name: Set adapter logging to debug
+#     itential.platform.set_adapter_log_level:
+#       adapter_name: network-adapter
+#       log_level: debug
+
+from ansible.plugins.action import ActionBase
+from ansible_collections.itential.platform.plugins.module_utils.request import make_request
+from ansible.errors import AnsibleError
+
+class ActionModule(ActionBase):
+
+    _supports_check_mode = False
+    _supports_async = False
+    _requires_connection = False
+
+    def run(self, tmp=None, task_vars=None):
+        adapter_name = self._task.args.get("adapter_name")
+        log_level = self._task.args.get("log_level")
+        transport = self._task.args.get("transport")
+
+        if not adapter_name or not log_level or not transport:
+            raise AnsibleError("adapter_name, log_level, and transport must be provided.")
+
+        endpoint = f"/adapters/{adapter_name}/loglevel"
+        method = "PUT"
+
+        data = {
+            "properties": {
+                "transport": transport,
+                "level": log_level
+            }
+        }
+
+        return make_request(task_vars, method, endpoint, data=data)
+

--- a/plugins/modules/set_adapter_log_level.py
+++ b/plugins/modules/set_adapter_log_level.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python
+
+# Copyright 2024, Itential Inc. All Rights Reserved
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = """
+---
+module: itential.platform.worker_status
+author: Itential
+
+short_description: Get a list of active tasks from an Itential Platform system
+
+description:
+  - The M(itential.platform.worker_status) module returns a list of active 
+  tasks from an Itential Platform system.
+"""
+
+
+EXAMPLES = """
+  - name: get a list of active tasks
+    itential.platform.worker_status:
+"""

--- a/plugins/modules/set_adapter_log_level.py
+++ b/plugins/modules/set_adapter_log_level.py
@@ -10,18 +10,48 @@ __metaclass__ = type
 
 DOCUMENTATION = """
 ---
-module: itential.platform.worker_status
+module: set_adapter_log_level
 author: Itential
-
-short_description: Get a list of active tasks from an Itential Platform system
+short_description: Set the logging level for a specific Itential Platform adapter
 
 description:
-  - The M(itential.platform.worker_status) module returns a list of active 
-  tasks from an Itential Platform system.
+  - The C(set_adapter_log_level) module configures the log level and transport
+    method (file or console) for a specific adapter running on the Itential Platform.
+
+options:
+  adapter_name:
+    description:
+      - Name of the adapter to update the logging level for.
+    required: true
+    type: str
+
+  log_level:
+    description:
+      - Logging level to set for the adapter.
+      - Common values include C(debug), C(info), C(warn), C(error).
+    required: true
+    type: str
+
+  transport:
+    description:
+      - Output transport to apply the log level to.
+      - Valid values are C(file) and C(console).
+    required: true
+    type: str
 """
 
-
 EXAMPLES = """
-  - name: get a list of active tasks
-    itential.platform.worker_status:
+- name: Set adapter logging to debug using file transport
+  itential.platform.set_adapter_log_level:
+    adapter_name: network-adapter
+    log_level: debug
+    transport: file
+"""
+
+RETURN = """
+changed:
+  description: Whether the log level was successfully updated.
+  returned: always
+  type: bool
+  sample: true
 """


### PR DESCRIPTION
Forgot to add this module before. This is used by the operator toolkit, so it needs to be included in the galaxy collection before lint can pass.